### PR TITLE
ASC-497 validate all string arguments in a given mark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ clean-venv: uninstall check-venv ## remove all packages from current virtual env
 	@source virtualenvwrapper.sh && wipeenv || echo "Skipping wipe of environment"
 
 lint: clean install-dev-requirements ## check style with flake8
-	flake8 pytest-mark-checker tests --ignore M
+	flake8 flake8_pytest_mark.py tests --ignore M
 
 test: ## run tests quickly with the default Python
 	py.test

--- a/doc/violation_codes.rst
+++ b/doc/violation_codes.rst
@@ -13,5 +13,7 @@ flak8-pytest-mark is a flake8 plugin that validates the presence of given pytest
 +------+--------------------------------------------------------------------------------------------------+
 | M6XX | does not match the configuration specified by pytest_mark1, badly formed hexadecimal UUID string |
 +------+--------------------------------------------------------------------------------------------------+
+| M7XX | mark values must be strings                                                                      |
++------+--------------------------------------------------------------------------------------------------+
 
 The codes referenced in the table above that end in XX are configurable.  Up to 50 instances may be created.

--- a/flake8_pytest_mark.py
+++ b/flake8_pytest_mark.py
@@ -65,6 +65,9 @@ class MarkChecker(object):
             node (ast.AST): A node in the ast.
             rule_name (str): The name of the rule.
             rule_conf (dict): The dictionary containing the properties of the rule
+
+        Yields:
+            tuple: (int, int, str, type) the tuple used by flake8 to construct a violation
         """
         if isinstance(node, ast.FunctionDef):
             marked = False
@@ -93,6 +96,9 @@ class MarkChecker(object):
             node (ast.AST): A node in the ast.
             rule_name (str): The name of the rule.
             rule_conf (dict): The dictionary containing the properties of the rule
+
+        Yields:
+            tuple: (int, int, str, type) the tuple used by flake8 to construct a violation
         """
         if isinstance(node, ast.FunctionDef):
             configured = False
@@ -149,6 +155,9 @@ class MarkChecker(object):
             node (ast.AST): A node in the ast.
             rule_name (str): The name of the rule.
             rule_conf (dict): The dictionary containing the properties of the rule
+
+        Yields:
+            tuple: (int, int, str, type) the tuple used by flake8 to construct a violation
         """
         if isinstance(node, ast.FunctionDef):
             line_num = node.lineno

--- a/flake8_pytest_mark.py
+++ b/flake8_pytest_mark.py
@@ -120,9 +120,7 @@ class MarkChecker(object):
                             # iterate through values to test all for matching
                             for value in values:
                                 if 'value_regex' in rule_conf:
-                                    if re.match(rule_conf['value_regex'], value):
-                                        pass
-                                    else:
+                                    if not re.match(rule_conf['value_regex'], value):
                                         non_matching_values.append(value)
                                         detailed_error = "Configured regex: '{}'".format(rule_conf['value_regex'])
 

--- a/flake8_pytest_mark.py
+++ b/flake8_pytest_mark.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 import ast
-import flake8
-import ast
 import re
 from uuid import UUID
 
@@ -41,8 +39,9 @@ class MarkChecker(object):
                 d[pytest_mark] = parsed_params
         cls.pytest_marks.update(d)
         # delete any empty rules
-        cls.pytest_marks = {x:y for x,y in cls.pytest_marks.items() if len(y) > 0}
+        cls.pytest_marks = {x: y for x, y in cls.pytest_marks.items() if len(y) > 0}
 
+    # noinspection PyUnusedLocal,PyUnusedLocal
     def __init__(self, tree, *args, **kwargs):
         self.tree = tree
 
@@ -50,14 +49,14 @@ class MarkChecker(object):
         if len(self.pytest_marks) == 0:
             message = "M401 no configuration found for {}, please provide configured marks in a flake8 config".format(self.name)  # noqa: E501
             yield (0, 0, message, type(self))
-        rule_funcs = (self.rule_M5XX, self.rule_M6XX)
+        rule_funcs = (self.rule_m5xx, self.rule_m6xx)
         for node in ast.walk(self.tree):
             for rule_func in rule_funcs:
                 for rule_name, configured_rule in self.pytest_marks.items():
                     for err in rule_func(node, rule_name, configured_rule):
                         yield err
 
-    def rule_M5XX(self, node, rule_name, rule_conf):
+    def rule_m5xx(self, node, rule_name, rule_conf):
         """Read and validate the input file contents.
         A 5XX rule checks for the presence of a configured 'pytest_mark'
         Marks may be numbered up to 50, example: 'pytest_mark49'
@@ -88,7 +87,7 @@ class MarkChecker(object):
                 if not marked:
                     yield (line_num, 0, message, type(self))
 
-    def rule_M6XX(self, node, rule_name, rule_conf):
+    def rule_m6xx(self, node, rule_name, rule_conf):
         """Validate a value to a given mark against a provided regex
         A 6XX requires a configured 5XX rule
         A 6XX rule will not warn if a corresponding 5XX rule validates

--- a/tests/test_match_validation.py
+++ b/tests/test_match_validation.py
@@ -52,7 +52,7 @@ def test_happy_path():
     pass
     """)
     result = flake8dir.run_flake8(extra_args)
-    expected = ["./example.py:1:1: M601 the mark value 'this is a bad value' does not match the configuration specified by pytest_mark1, badly formed hexadecimal UUID string"]  # noqa: E501
+    expected = ["./example.py:1:1: M601 the mark values '['this is a bad value']' do not match the configuration specified by pytest_mark1, badly formed hexadecimal UUID string"]  # noqa: E501
     observed = result.out_lines
     pytest.helpers.assert_lines(expected, observed)
 
@@ -79,7 +79,7 @@ def test_happy_path():
     """)
     result = flake8dir.run_flake8(extra_args)
     observed = result.out_lines
-    expected = [r"./example.py:1:1: M601 the mark value 'this_should_fail' does not match the configuration specified by pytest_mark1, Configured regex: '^this_is_a_regex'"]  # noqa: E501
+    expected = [r"./example.py:1:1: M601 the mark values '['this_should_fail']' do not match the configuration specified by pytest_mark1, Configured regex: '^this_is_a_regex'"]  # noqa: E501
     pytest.helpers.assert_lines(expected, observed)
 
 
@@ -98,8 +98,8 @@ def test_i_will_fail_too():
     """)
     result = flake8dir.run_flake8(extra_args)
     observed = result.out_lines
-    expected = [r"./example.py:1:1: M601 the mark value 'this_should_fail' does not match the configuration specified by pytest_mark1, Configured regex: '^this_is_a_regex'",  # noqa: E501
-                r"./example.py:6:1: M602 the mark value 'babe2863-4284-11e8-9eca-6c96cfdf5101fail' does not match the configuration specified by pytest_mark2, badly formed hexadecimal UUID string"]  # noqa: E501
+    expected = [r"./example.py:1:1: M601 the mark values '['this_should_fail']' do not match the configuration specified by pytest_mark1, Configured regex: '^this_is_a_regex'",  # noqa: E501
+                r"./example.py:6:1: M602 the mark values '['babe2863-4284-11e8-9eca-6c96cfdf5101fail']' do not match the configuration specified by pytest_mark2, badly formed hexadecimal UUID string"]  # noqa: E501
     pytest.helpers.assert_lines(expected, observed)
 
 
@@ -112,5 +112,5 @@ def test_i_will_fail():
     """)
     result = flake8dir.run_flake8(extra_args)
     observed = result.out_lines
-    expected = [r"./example.py:1:1: M601 the mark value 'b360c12d-0d47-4cfc-9f9e-5d86c315b1e4' does not match the configuration specified by pytest_mark1, Configured regex: '^this_is_a_regex'"]  # noqa: E501
+    expected = [r"./example.py:1:1: M601 the mark values '['b360c12d-0d47-4cfc-9f9e-5d86c315b1e4']' do not match the configuration specified by pytest_mark1, Configured regex: '^this_is_a_regex'"]  # noqa: E501
     pytest.helpers.assert_lines(expected, observed)

--- a/tests/test_multi_value_mark.py
+++ b/tests/test_multi_value_mark.py
@@ -52,3 +52,13 @@ def test_happy_path():
     """)
     result = flake8dir.run_flake8(extra_args)
     assert result.out_lines == [u'./example.py:1:1: M501 mark values must be strings']
+
+def test_multiple_values_that_are_not_strings(flake8dir):
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.jira('ASC-432', ['ASC-123', 'ASC-124'], 'RE-234')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == [u'./example.py:1:1: M501 mark values must be strings']

--- a/tests/test_multi_value_mark.py
+++ b/tests/test_multi_value_mark.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# args to only use checks that raise an 'M' prefixed error
+extra_args = ['--select', 'M']
+
+config = """
+[flake8]
+pytest_mark1 = name=jira,value_regex=[a-zA-Z]*-\d*
+
+"""
+
+
+def test_with_valid_test_id_marks(flake8dir):
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.jira('ASC-123', 'ASC-124', 'ASC-125')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_with_invalid_test_id_mark(flake8dir):
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.jira('ASC-123', 'not_good', 'ASC-125')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == ["./example.py:1:1: M601 the mark values '['not_good']' do not match the configuration specified by pytest_mark1, Configured regex: '[a-zA-Z]*-\\d*'"]  # noqa
+
+
+def test_with_multiple_invalid_test_id_mark(flake8dir):
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.jira('bad', 'not_good', 'really bad')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == ["./example.py:1:1: M601 the mark values '['bad', 'not_good', 'really bad']' do not match the configuration specified by pytest_mark1, Configured regex: '[a-zA-Z]*-\\d*'"]  # noqa
+
+
+def test_values_that_are_not_strings(flake8dir):
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.jira(['ASC-123', 'ASC-124', 'ASC-125'])
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == [u'./example.py:1:1: M501 mark values must be strings']

--- a/tests/test_multi_value_mark.py
+++ b/tests/test_multi_value_mark.py
@@ -53,6 +53,7 @@ def test_happy_path():
     result = flake8dir.run_flake8(extra_args)
     assert result.out_lines == [u'./example.py:1:1: M501 mark values must be strings']
 
+
 def test_multiple_values_that_are_not_strings(flake8dir):
     flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""

--- a/tests/test_multi_value_mark.py
+++ b/tests/test_multi_value_mark.py
@@ -51,7 +51,7 @@ def test_happy_path():
     pass
     """)
     result = flake8dir.run_flake8(extra_args)
-    assert result.out_lines == [u'./example.py:1:1: M501 mark values must be strings']
+    assert result.out_lines == [u'./example.py:1:1: M701 mark values must be strings']
 
 
 def test_multiple_values_that_are_not_strings(flake8dir):
@@ -62,4 +62,4 @@ def test_happy_path():
     pass
     """)
     result = flake8dir.run_flake8(extra_args)
-    assert result.out_lines == [u'./example.py:1:1: M501 mark values must be strings']
+    assert result.out_lines == [u'./example.py:1:1: M701 mark values must be strings']

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ python =
 basepython = python
 skip_install = true
 deps = flake8
-commands = flake8 pytest-mark-checker tests --ignore M
+commands = flake8 flake8_pytest_mark.py tests --ignore M
 
 [testenv]
 setenv =


### PR DESCRIPTION
- rejects all arguments that are not strings
- when configured to match, will match all supplied args to given mark