### PR TITLE
ASC-513 Validate number of string arguments to a given mark

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -73,4 +73,14 @@ All examples assume running against the following test file.
     def test_multiple_marks():
         pass
 
+**multiple_arg_example.py** : With above configuration flake8-pytest-mark will raise a violation by default::
+
+    @pytest.mark.test_type('functional', 'unit')
+    def test_multiple_marks():
+        pass
+
+**Shell Output** : Validating one mark not present & one mark value does not match::
+
+    ./example.py:1:1: M901 you may only specify one argument to @pytest.mark.test_type'
+
 .. _Flake8_configuration: http://flake8.pycqa.org/en/latest/user/configuration.html

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,15 +15,17 @@ Configuration
 You may configure up to 50 pytest-marks to be validated.  Flake8-pytest-mark will only validate marks that accept a single string as an argument ``@pytest.mark.test_id('I_am_a_string')``.  IF you would like to match the value of a marks string you may supply one of the following parameters.
 
 
-+-----------------+----------------------------------------------+----------------------------------------------------------------+
-| Param Name      + Valid Argument                               + Explanation                                                    +
-+=================+==============================================+================================================================+
-| value_match     + uuid                                         + Will validate the the supplied string is a valid UUID          |
-+-----------------+----------------------------------------------+----------------------------------------------------------------+
-| value_regex     + any valid regex that does not contain spaces | Will validate that the supplied string is a match to the regex |
-+-----------------+----------------------------------------------+----------------------------------------------------------------+
-| allow_duplicate + false (default), true                        | Allows a mark to decorate a test more than once                |
-+-----------------+----------------------------------------------+----------------------------------------------------------------+
++---------------------+----------------------------------------------+----------------------------------------------------------------+
+| Param Name          + Valid Argument                               + Explanation                                                    +
++=====================+==============================================+================================================================+
+| value_match         + uuid                                         + Will validate the the supplied string is a valid UUID          |
++---------------------+----------------------------------------------+----------------------------------------------------------------+
+| value_regex         + any valid regex that does not contain spaces | Will validate that the supplied string is a match to the regex |
++---------------------+----------------------------------------------+----------------------------------------------------------------+
+| allow_duplicate     + false (default), true                        | Allows a mark to decorate a test more than once                |
++---------------------+----------------------------------------------+----------------------------------------------------------------+
+| allow_multiple_args + false (default), true                        | Allows a decorator to receive multiple arguments               |
++---------------------+----------------------------------------------+----------------------------------------------------------------+
 
 Examples:
 =========
@@ -82,5 +84,11 @@ All examples assume running against the following test file.
 **Shell Output** : Validating one mark not present & one mark value does not match::
 
     ./example.py:1:1: M901 you may only specify one argument to @pytest.mark.test_type'
+
+**.flake8** : Configuration, configure a mark that allows for multiple arguments::
+
+    [flake8]
+    pytest_mark1 = name=test_id,
+                   allow_multiple_args=true
 
 .. _Flake8_configuration: http://flake8.pycqa.org/en/latest/user/configuration.html

--- a/docs/violation_codes.rst
+++ b/docs/violation_codes.rst
@@ -17,5 +17,7 @@ flak8-pytest-mark is a flake8 plugin that validates the presence of given pytest
 +------+--------------------------------------------------------------------------------------------------+
 | M8XX | @pytest.mark.<mark_name> may only be called once for a given test                                |
 +------+--------------------------------------------------------------------------------------------------+
+| M9XX | you may only specify one argument to @pytest.mark.<mark_name>                                    |
++------+--------------------------------------------------------------------------------------------------+
 
 The codes referenced in the table above that end in XX are configurable.  Up to 50 instances may be created.

--- a/flake8_pytest_mark/__init__.py
+++ b/flake8_pytest_mark/__init__.py
@@ -23,7 +23,8 @@ class MarkChecker(object):
         """Required by flake8
         add the possible options, called first
 
-        parser (OptionsManager):
+        Args:
+            parser (OptionsManager):
         """
         kwargs = {'action': 'store', 'default': '', 'parse_from_config': True,
                   'comma_separated_list': True}
@@ -35,7 +36,8 @@ class MarkChecker(object):
         """Required by flake8
         parse the options, called after add_options
 
-        options (dict): options to be parsed
+        Args:
+            options (dict): options to be parsed
         """
         d = {}
         for pytest_mark, dictionary in cls.pytest_marks.items():
@@ -57,9 +59,10 @@ class MarkChecker(object):
     def __init__(self, tree, *args, **kwargs):
         """Required by flake8
 
-        tree (ast.AST): an AST tree
-        args:
-        kwargs:
+        Args:
+            tree (ast.AST): an AST tree
+            args:
+            kwargs:
         """
         self.tree = tree
 

--- a/flake8_pytest_mark/__init__.py
+++ b/flake8_pytest_mark/__init__.py
@@ -46,7 +46,7 @@ class MarkChecker(object):
                 for single_line in mark_data:
                     a = [s.strip() for s in single_line.split('=')]
                     # whitelist the acceptable params
-                    if a[0] in ['name', 'value_match', 'value_regex', 'allow_duplicate']:
+                    if a[0] in ['name', 'value_match', 'value_regex', 'allow_duplicate', 'allow_multiple_args']:
                         parsed_params[a[0]] = a[1]
                 d[pytest_mark] = parsed_params
         cls.pytest_marks.update(d)
@@ -74,7 +74,7 @@ class MarkChecker(object):
             message = "M401 no configuration found for {}, " \
                       "please provide configured marks in a flake8 config".format(self.name)
             yield (0, 0, message, type(self))
-        rule_funcs = (rules.rule_m5xx, rules.rule_m6xx, rules.rule_m7xx, rules.rule_m8xx)
+        rule_funcs = (rules.rule_m5xx, rules.rule_m6xx, rules.rule_m7xx, rules.rule_m8xx, rules.rule_m9xx)
         for node in ast.walk(self.tree):
             if isinstance(node, ast.FunctionDef) and re.match(r'^test_', node.name):
                 for rule_func in rule_funcs:

--- a/flake8_pytest_mark/rules.py
+++ b/flake8_pytest_mark/rules.py
@@ -20,8 +20,7 @@ def rule_m5xx(node, rule_name, rule_conf, class_type):
         tuple: (int, int, str, type) the tuple used by flake8 to construct a violation
     """
     line_num = node.lineno
-    code = ''.join([i for i in str(rule_name) if i.isdigit()])
-    code = code.zfill(2)
+    code = _generate_mark_code(rule_name)
     message = 'M5{} test definition not marked with {}'.format(code, rule_conf['name'])
     if not _reduce_decorators_by_mark(node.decorator_list, rule_conf['name']):
         yield (line_num, 0, message, class_type)
@@ -73,8 +72,7 @@ def rule_m6xx(node, rule_name, rule_conf, class_type):
                             detailed_error = e
 
     if configured and len(non_matching_values) > 0:
-        code = ''.join([i for i in str(rule_name) if i.isdigit()])
-        code = code.zfill(2)
+        code = _generate_mark_code(rule_name)
         message = "M6{} the mark values '{}' do not match the configuration specified by {}, {}".format(code, non_matching_values, rule_name, detailed_error)   # noqa: E501
         yield (line_num, 0, message, class_type)
 
@@ -93,8 +91,7 @@ def rule_m7xx(node, rule_name, rule_conf, class_type):
         tuple: (int, int, str, type) the tuple used by flake8 to construct a violation
     """
     line_num = node.lineno
-    code = ''.join([i for i in str(rule_name) if i.isdigit()])
-    code = code.zfill(2)
+    code = _generate_mark_code(rule_name)
     message = False
     for decorator in _reduce_decorators_by_mark(node.decorator_list, rule_conf['name']):
         if any(not isinstance(arg, ast.Str) for arg in decorator.args):
@@ -118,12 +115,36 @@ def rule_m8xx(node, rule_name, rule_conf, class_type):
     """
 
     line_num = node.lineno
-    code = ''.join([i for i in str(rule_name) if i.isdigit()])
-    code = code.zfill(2)
+    code = _generate_mark_code(rule_name)
     message = 'M8{} @pytest.mark.{} may only be called once for a given test'.format(code, rule_conf['name'])
     allow_dupe = True if 'allow_duplicate' in rule_conf and rule_conf['allow_duplicate'].lower() == 'true' else False
     if not allow_dupe and len(_reduce_decorators_by_mark(node.decorator_list, rule_conf['name'])) > 1:
         yield (line_num, 0, message, class_type)
+
+
+def rule_m9xx(node, rule_name, rule_conf, class_type):
+    """Validates the number of arguments to @pytest.mark.foo()
+    By default we validate that there is only one argument
+    can configure to allow multiple with allow_multiple_args=true
+
+    Args:
+        node (ast.AST): A node in the ast.
+        rule_name (str): The name of the rule.
+        rule_conf (dict): The dictionary containing the properties of the rule
+        class_type (class): The class that this rule was called from
+
+    Yields:
+        tuple: (int, int, str, type) the tuple used by flake8 to construct a violation
+    """
+    line_num = node.lineno
+    code = _generate_mark_code(rule_name)
+    allow_multiple_args = False
+    if 'allow_multiple_args' in rule_conf and rule_conf['allow_multiple_args'].lower() == 'true':
+        allow_multiple_args = True
+    for decorator in _reduce_decorators_by_mark(node.decorator_list, rule_conf['name']):
+        if not allow_multiple_args and len(decorator.args) > 1:
+            message = 'M9{} you may only specify one argument to @pytest.mark.{}'.format(code, rule_conf['name'])
+            yield (line_num, 0, message, class_type)
 
 
 def _reduce_decorators_by_mark(decorators, mark):
@@ -164,3 +185,17 @@ def _get_decorator_args(decorator):
     except AttributeError:
         pass
     return args
+
+
+def _generate_mark_code(rule_name):
+    """Generates a two digit string based on a provided string
+
+    Args:
+        rule_name (str): A configured rule name 'pytest_mark3'.
+
+    Returns:
+        str: A two digit code based on the provided string '03'
+    """
+    code = ''.join([i for i in str(rule_name) if i.isdigit()])
+    code = code.zfill(2)
+    return code

--- a/tests/test_multi_value_mark.py
+++ b/tests/test_multi_value_mark.py
@@ -5,7 +5,7 @@ extra_args = ['--select', 'M']
 
 config = """
 [flake8]
-pytest_mark1 = name=jira,value_regex=[a-zA-Z]*-\d*
+pytest_mark1 = name=jira,value_regex=[a-zA-Z]*-\d*,allow_multiple_args=true
 
 """
 

--- a/tests/test_rule_m9xx.py
+++ b/tests/test_rule_m9xx.py
@@ -10,7 +10,7 @@ pytest_mark1 = name=test_id,
 """
 
 
-def test_with_duplicate_marks(flake8dir):
+def test_with_multiple_arguments(flake8dir):
     flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.test_id('too', 'many', 'args')

--- a/tests/test_rule_m9xx.py
+++ b/tests/test_rule_m9xx.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# args to only use checks that raise an 'M' prefixed error
+extra_args = ['--select', 'M']
+
+config = """
+[flake8]
+pytest_mark1 = name=test_id,
+
+"""
+
+
+def test_with_duplicate_marks(flake8dir):
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('too', 'many', 'args')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == [u'./example.py:1:1: M901 you may only specify one argument to @pytest.mark.test_id']


### PR DESCRIPTION
- adds new violation code M9xx
- validates one string argument per mark by default
- can be configured with allow_multiple_args=true