### PR TITLE
ASC-919 Enforce Mark Checking on All Test Definition Types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Flake8-pytest-mark
 .. image:: https://travis-ci.org/rcbops/flake8-pytest-mark.svg?branch=master
     :target: https://travis-ci.org/rcbops/flake8-pytest-mark
 
-Check and enforce the presence of a mark on a pytest test case.
+Check and enforce the presence of a mark on a pytest test definition classes, methods and functions.
 
 Quick Start Guide
 -----------------
@@ -32,8 +32,9 @@ Quick Start Guide
 Gotchas
 -------
 
-1. It is highly recommended to use this plugin inside of a virtualenv
-2. A configuration is required by this plugin, if none is found the plugin will throw a M401 validation error for every file
+1. It is highly recommended to use this plugin inside of a virtualenv.
+2. A configuration is required by this plugin, if none is found the plugin will throw a M401 validation error for every file.
+3. By default this plug-in will enforce marks against pytest test classes. (See configuration_ for more details on how to exclude different pytest test definitions from mark checking.)
 
 Violation Codes
 ---------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,19 +15,25 @@ Configuration
 You may configure up to 50 pytest-marks to be validated.  Flake8-pytest-mark will only validate marks that accept a single string as an argument ``@pytest.mark.test_id('I_am_a_string')``.  IF you would like to match the value of a marks string you may supply one of the following parameters.
 
 
-+----------------------+----------------------------------------------+----------------------------------------------------------------+
-| Param Name           + Valid Argument                               + Explanation                                                    +
-+======================+==============================================+================================================================+
-| value_match          + uuid                                         + Will validate the the supplied string is a valid UUID          |
-+----------------------+----------------------------------------------+----------------------------------------------------------------+
-| value_regex          + any valid regex that does not contain spaces | Will validate that the supplied string is a match to the regex |
-+----------------------+----------------------------------------------+----------------------------------------------------------------+
-| allow_duplicate      + false (default), true                        | Allows a mark to decorate a test more than once                |
-+----------------------+----------------------------------------------+----------------------------------------------------------------+
-| allow_multiple_args  + false (default), true                        | Allows a decorator to receive multiple arguments               |
-+----------------------+----------------------------------------------+----------------------------------------------------------------+
-| enforce_unique_value + false (default), true                        | Enforces that mark value must be unique across all occurrences |
-+----------------------+----------------------------------------------+----------------------------------------------------------------+
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| Param Name           + Valid Argument                               + Explanation                                                       +
++======================+==============================================+===================================================================+
+| value_match          + uuid                                         + Will validate the the supplied string is a valid UUID             |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| value_regex          + any valid regex that does not contain spaces | Will validate that the supplied string is a match to the regex    |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| allow_duplicate      + false (default), true                        | Allows a mark to decorate a test more than once                   |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| allow_multiple_args  + false (default), true                        | Allows a decorator to receive multiple arguments                  |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| enforce_unique_value + false (default), true                        | Enforces that mark value must be unique across all occurrences    |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| exclude_classes      + false (default), true                        | Exclude test classes from rule processing                         |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| exclude_methods      + false (default), true                        | Exclude test methods from rule processing                         |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
+| exclude_functions    + false (default), true                        | Exclude test functions from rule processing                       |
++----------------------+----------------------------------------------+-------------------------------------------------------------------+
 
 Examples:
 =========
@@ -97,7 +103,7 @@ All examples assume running against the following test file.
 
     [flake8]
     pytest_mark1 = name=test_id,
-                   enforce_unique_value=true,
+                   enforce_unique_value=true
 
 **unique_example.py** : With above configuration flake8-pytest-mark will raise an M3XX violation::
 
@@ -112,5 +118,21 @@ All examples assume running against the following test file.
 **Shell Output** : Violation triggered because the value for "test_id" mark is not unique across all mark occurrences::
 
     ./example.py:5:1: M301 @pytest.mark.test value is not unique! The 'unique_test_id' mark value already specified for the 'test_unique_mark1' test at line '1' found in the './example.py' file!
+
+**.flake8** : Configuration, configure a mark to exclude classes from rule processing::
+
+    [flake8]
+    pytest_mark1 = name=test,
+                   exclude_classes=true
+
+**exclude_class_example.py** : With above configuration flake8-pytest-mark will raise an M5XX violation against the test method but not the class::
+
+    def TestClassMark(object):
+        def test_method(self):
+            pass
+
+**Shell Output** : Violation triggered because the value for "test" mark is not present on the method while the class is ignored::
+
+    ./example.py:2:1: M501 test definition not marked with test
 
 .. _Flake8_configuration: http://flake8.pycqa.org/en/latest/user/configuration.html

--- a/docs/example_config.cfg
+++ b/docs/example_config.cfg
@@ -1,5 +1,7 @@
 [flake8]
 pytest_mark1 = name=test_id
                value_match=uuid
+               exclude_classes=true
 pytest_mark2 = name=test_name
                value_regex=^test.*
+               exclude_classes=true

--- a/flake8_pytest_mark/__init__.py
+++ b/flake8_pytest_mark/__init__.py
@@ -1,22 +1,48 @@
 # -*- coding: utf-8 -*-
+
+# ======================================================================================================================
+# Imports
+# ======================================================================================================================
 import ast
 import re
 from flake8_pytest_mark import rules
 
+# ======================================================================================================================
+# Globals
+# ======================================================================================================================
 __author__ = 'rpc-automation'
 __email__ = 'rpc-automation@rackspace.com'
 __version__ = '0.5.0'
 
 
+# ======================================================================================================================
+# Classes
+# ======================================================================================================================
 class MarkChecker(object):
     """
     Flake8 plugin to check the presence of test marks.
     """
+
     name = 'flake8-pytest-mark'
     version = __version__
     min_mark = 1
     max_mark = 50
+    test_def_regex = re.compile(r'^(test_)|(Test)')
     pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(min_mark, max_mark)], {})
+
+    # noinspection PyUnusedLocal,PyUnusedLocal
+    def __init__(self, tree, filename, *args, **kwargs):
+        """Required by flake8
+
+        Args:
+            tree (ast.AST): An AST tree. (Required by flake8, but never used by this plug-in)
+            filename (str): The name of the file to evaluate.
+            args (list): A list of positional arguments.
+            kwargs (dict): A dictionary of keyword arguments.
+        """
+
+        self.tree = tree
+        self.filename = filename
 
     @classmethod
     def add_options(cls, parser):
@@ -41,8 +67,15 @@ class MarkChecker(object):
         """
 
         d = {}
-        acceptable_params = \
-            ['name', 'value_match', 'value_regex', 'allow_duplicate', 'allow_multiple_args', 'enforce_unique_value']
+        acceptable_params = ['name',
+                             'value_match',
+                             'value_regex',
+                             'allow_duplicate',
+                             'allow_multiple_args',
+                             'enforce_unique_value',
+                             'exclude_classes',
+                             'exclude_methods',
+                             'exclude_functions']
 
         for pytest_mark, dictionary in cls.pytest_marks.items():
             # retrieve the marks from the passed options
@@ -61,20 +94,6 @@ class MarkChecker(object):
         # delete any empty rules
         cls.pytest_marks = {x: y for x, y in cls.pytest_marks.items() if len(y) > 0}
 
-    # noinspection PyUnusedLocal,PyUnusedLocal
-    def __init__(self, tree, filename, *args, **kwargs):
-        """Required by flake8
-
-        Args:
-            tree (ast.AST): An AST tree. (Required by flake8, but never used by this plug-in)
-            filename (str): The name of the file to evaluate.
-            args (list): A list of positional arguments.
-            kwargs (dict): A dictionary of keyword arguments.
-        """
-
-        self.tree = tree
-        self.filename = filename
-
     def run(self):
         """Required by flake8
         will be called after add_options and parse_options
@@ -92,12 +111,52 @@ class MarkChecker(object):
             yield (0, 0, message, type(self))
 
         for node in ast.walk(self.tree):
-            if isinstance(node, ast.FunctionDef) and re.match(r'^test_', node.name):
+            if type(node) in (ast.FunctionDef, ast.ClassDef) and self.test_def_regex.match(node.name):
                 for rule_func in rule_funcs:
-                    for rule_name, configured_rule in self.pytest_marks.items():
+                    for rule_name, rule_conf in self.pytest_marks.items():
+                        # Skip nodes that fail process evaluation
+                        if not self._process_node_evaluation(rule_conf, node):
+                            continue
+
                         for err in rule_func(node=node,
                                              rule_name=rule_name,
-                                             rule_conf=configured_rule,
+                                             rule_conf=rule_conf,
                                              class_type=type(self),
                                              filename=self.filename):
                             yield err
+
+    @classmethod
+    def _process_node_evaluation(cls, rule_conf, node):
+        """Evaluate whether a node should be processed or not based on configuration options specified by the user.
+
+        Args:
+            rule_conf (dict): The rules configuration to use for evaluation.
+            node (ast.stmt): The node under evaluation.
+
+        Returns:
+            bool: True if node should be processed by rules otherwise False.
+        """
+
+        process_rule_flag = True
+
+        if type(node) == ast.FunctionDef:
+            # Determine if test function definition meets the criteria of being a class method.
+            if len(node.args.args) > 0:
+                # Compatibility check between Python 2.7 and Python 3.x.
+                if getattr(node.args.args[0], 'id', '') == 'self' or getattr(node.args.args[0], 'arg', '') == 'self':
+                    # Skip processing test method node if 'exclude_methods' is 'true'
+                    if 'exclude_methods' in rule_conf and rule_conf['exclude_methods'].lower() == 'true':
+                        process_rule_flag = False
+
+            # Skip processing node if a test function definition and 'exclude_functions' is 'true'
+            elif 'exclude_functions' in rule_conf \
+                    and rule_conf['exclude_functions'].lower() == 'true':
+                process_rule_flag = False
+
+        # Skip processing node if a test class definition and 'exclude_classes' is 'true'
+        elif type(node) == ast.ClassDef \
+                and 'exclude_classes' in rule_conf \
+                and rule_conf['exclude_classes'].lower() == 'true':
+            process_rule_flag = False
+
+        return process_rule_flag

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 -c constraints.txt
-tox
+bumpversion
 flake8
+ipython
 pytest
-pytest-mock
 pytest-flake8dir
 pytest-helpers-namespace
+pytest-mock
+tox
 twine
-bumpversion

--- a/tests/test_exclusions.py
+++ b/tests/test_exclusions.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for validating rules processing exclusions for test methods and functions. (Driven by the 'exclude_methods'
+and 'exclude_functions' options.)
+"""
+
+# ======================================================================================================================
+# Imports
+# ======================================================================================================================
+import pytest
+
+
+# ======================================================================================================================
+# Globals
+# ======================================================================================================================
+# args to only use checks that raise an 'M' prefixed error
+extra_args = ['--select', 'M']
+
+
+# ======================================================================================================================
+# Test Suites
+# ======================================================================================================================
+class TestExcludeClasses(object):
+    """Tests for validating the 'exclude_classes' option works as expected."""
+
+    # Test suite variables
+    config = """
+[flake8]
+pytest_mark1 = name=test,exclude_classes=true
+
+"""
+
+    def test_enable_exclude_classes_configuration(self, flake8dir):
+        """Verify rules that explicitly enable the 'exclude_classes' configuration will ignore classes that are
+        missing required marks.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg(self.config)
+        flake8dir.make_example_py("""
+class TestDisabledConfiguration(object):
+    pass
+""")
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert [] == result.out_lines
+
+    def test_enabled_with_class_containing_tests(self, flake8dir):
+        """Verify rules that explicitly enable the 'exclude_classes' configuration will ignore classes that are
+        missing required marks, but will still trigger violations on test functions contained within the class.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg(self.config)
+        flake8dir.make_example_py("""
+class TestUnconfigured(object):
+    def test_function(self):
+        pass
+    """)
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert ['./example.py:2:1: M501 test definition not marked with test'] == result.out_lines
+
+    def test_unconfigured_with_class_containing_tests(self, flake8dir):
+        """Verify rules that leave the 'exclude_classes' option unconfigured will trigger violations on test functions
+        contained within the class as well as the class itself.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg("""
+[flake8]
+pytest_mark1 = name=test
+
+""")
+
+        flake8dir.make_example_py("""
+class TestUnconfigured(object):
+    def test_function(self):
+        pass
+""")
+
+        # Expectations
+        exp_out_lines = ['./example.py:1:1: M501 test definition not marked with test',
+                         './example.py:2:1: M501 test definition not marked with test']
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        # noinspection PyUnresolvedReferences
+        pytest.helpers.assert_lines(exp_out_lines, result.out_lines)
+
+
+class TestExcludeFunctions(object):
+    """Tests for validating the 'exclude_functions' option works as expected."""
+
+    # Test suite variables
+    config = """
+[flake8]
+pytest_mark1 = name=test,exclude_functions=true
+
+"""
+
+    def test_enable_exclude_functions_configuration(self, flake8dir):
+        """Verify that a violation is not triggered on a function that is missing a required mark with the
+        'exclude_functions' option set to 'true'.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg(self.config)
+        flake8dir.make_example_py("""
+def test_exclude_function():
+    pass
+""")
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert [] == result.out_lines
+
+
+class TestExcludeMethods(object):
+    """Tests for validating the 'exclude_methods' option works as expected."""
+
+    # Test suite variables
+    config = """
+[flake8]
+pytest_mark1 = name=test,exclude_methods=true
+
+"""
+
+    def test_enable_exclude_methods_configuration(self, flake8dir):
+        """Verify that a violation is not triggered on a method that is missing a required mark with the
+        'exclude_methods' option set to 'true'.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg(self.config)
+        flake8dir.make_example_py("""
+class TestExclusion(object):
+    def test_exclude_method(self):
+        pass
+""")
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert ['./example.py:1:1: M501 test definition not marked with test'] == result.out_lines
+
+    def test_exclude_method_with_class_properly_marked(self, flake8dir):
+        """Verify that a violation is not triggered on a method that is missing a required mark with the
+        'exclude_methods' option set to 'true'.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg(self.config)
+        flake8dir.make_example_py("""
+@pytest.mark.test('Classy!')
+class TestExclusion(object):
+    def test_exclude_method(self):
+        pass
+""")
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert [] == result.out_lines
+
+    def test_mangled_method_signature(self, flake8dir):
+        """Verify that a violation is triggered on a method that is missing a required mark with the 'exclude_methods'
+        option set to 'true' and the signature is mangled. (First element is not 'self')
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg(self.config)
+        flake8dir.make_example_py("""
+@pytest.mark.test('Classy!')
+class TestExclusion(object):
+    def test_exclude_method(me):
+        pass
+""")
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert ['./example.py:3:1: M501 test definition not marked with test'] == result.out_lines
+
+
+class TestMixedExclusions(object):
+    """Tests for validating that the various 'exclude_*' options can be combined in different fashions without
+    causing surprising behavior.
+    """
+
+    example_tests = """
+class TestClass(object):
+    def test_method(self):
+        pass
+
+def test_function():
+    pass
+"""
+
+    def test_no_exclusions_configured(self, flake8dir):
+        """Verify that violations are triggered on all supported test definition types when no exclusions are configured
+         and all test definitions are missing required marks.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg("""
+[flake8]
+pytest_mark1 = name=test
+
+""")
+        flake8dir.make_example_py(self.example_tests)
+
+        # Expectations
+        exp_out_lines = ['./example.py:1:1: M501 test definition not marked with test',
+                         './example.py:2:1: M501 test definition not marked with test',
+                         './example.py:5:1: M501 test definition not marked with test']
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        # noinspection PyUnresolvedReferences
+        pytest.helpers.assert_lines(exp_out_lines, result.out_lines)
+
+    def test_all_exclusions_configured(self, flake8dir):
+        """Verify that no violations are triggered on all supported test definition types when all exclusions are
+        configured and all test definitions are missing required marks.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg("""
+[flake8]
+pytest_mark1 = name=test,
+               exclude_classes=true,
+               exclude_methods=true,
+               exclude_functions=true
+
+""")
+        flake8dir.make_example_py(self.example_tests)
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert [] == result.out_lines
+
+    def test_classes_and_methods_excluded(self, flake8dir):
+        """Verify that only test function definition violations are triggered when 'exclude_classes' and
+        'exclude_methods' are configured and all test definitions are missing required marks.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg("""
+[flake8]
+pytest_mark1 = name=test,
+               exclude_classes=true,
+               exclude_methods=true,
+               exclude_functions=false
+
+""")
+        flake8dir.make_example_py(self.example_tests)
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert ['./example.py:5:1: M501 test definition not marked with test'] == result.out_lines
+
+    def test_classes_and_functions_excluded(self, flake8dir):
+        """Verify that only test function definition violations are triggered when 'exclude_classes' and
+        'exclude_functions' are configured and all test definitions are missing required marks.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg("""
+[flake8]
+pytest_mark1 = name=test,
+               exclude_classes=true,
+               exclude_methods=false,
+               exclude_functions=true
+
+""")
+        flake8dir.make_example_py(self.example_tests)
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert ['./example.py:2:1: M501 test definition not marked with test'] == result.out_lines
+
+    def test_methods_and_functions_excluded(self, flake8dir):
+        """Verify that only test function definition violations are triggered when 'exclude_methods' and
+        'exclude_functions' are configured and all test definitions are missing required marks.
+        """
+
+        # Setup
+        flake8dir.make_setup_cfg("""
+[flake8]
+pytest_mark1 = name=test,
+               exclude_classes=false,
+               exclude_methods=true,
+               exclude_functions=true
+
+""")
+        flake8dir.make_example_py(self.example_tests)
+
+        # Test
+        result = flake8dir.run_flake8(extra_args)
+        assert ['./example.py:1:1: M501 test definition not marked with test'] == result.out_lines

--- a/tests/test_mark_checking.py
+++ b/tests/test_mark_checking.py
@@ -41,6 +41,86 @@ def not_a_test():
     assert result.out_lines == []
 
 
+def test_class_with_test_id_mark(flake8dir):
+    """Verify that a properly marked class does not trigger a violation."""
+
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+class TestHappyPath(object):
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_class_without_test_id_mark(flake8dir):
+    """Verify that a class missing a required mark will trigger a violation."""
+
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+class TestSadPath(object):
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == ['./example.py:1:1: M501 test definition not marked with test_id']
+
+
+def test_classes_that_are_not_tests(flake8dir):
+    """Verify that a classes that do not follow the pytest test definition pattern are ignored."""
+
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+class NotATest(object):
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_methods_with_test_id_mark(flake8dir):
+    """Verify that a properly marked method does not trigger a violation."""
+
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+class TestClass(object):
+    @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+    def test_happy_path(self):
+        pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_method_without_test_id_mark(flake8dir):
+    """Verify that a method missing a required mark will trigger a violation."""
+
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+class TestClass(object):
+    def test_sad_path(self):
+        pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == ['./example.py:3:1: M501 test definition not marked with test_id']
+
+
+def test_methods_that_are_not_tests(flake8dir):
+    """Verify that a methods that do not follow the pytest test definition pattern are ignored."""
+
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+class TestClass(object):
+    def not_a_test(self):
+        pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
 def test_different_mark(flake8dir):
     flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""


### PR DESCRIPTION
Refactored codebase to enforce mark checking on test classes, methods and
functions. Added the 'exclude_classes', 'exclude_methods' and
'exclude_functions' to allow the user to control how mark check rules
should be applied to various pytest test definition types.