### PR TITLE
ASC-993 linter not respecting valid python styling

### DIFF
--- a/flake8_pytest_mark/rules.py
+++ b/flake8_pytest_mark/rules.py
@@ -241,7 +241,7 @@ def _reduce_decorators_by_mark(decorators, mark):
                     reduced.append(decorator)
             except AttributeError:
                 pass
-        if isinstance(decorator, ast.Attribute):
+        elif isinstance(decorator, ast.Attribute):
             try:
                 if decorator.attr == mark:
                     reduced.append(decorator)

--- a/flake8_pytest_mark/rules.py
+++ b/flake8_pytest_mark/rules.py
@@ -109,6 +109,9 @@ def rule_m6xx(node, rule_name, rule_conf, class_type, **kwargs):
         values = _get_decorator_args(decorator)
 
         if any(k in rule_conf for k in ('value_regex', 'value_match')):
+            if len(values) == 0:
+                non_matching_values.append('')
+                detailed_error = "Validation supplied, but values absent."
             # iterate through values to test all for matching
             for value in values:
                 if 'value_regex' in rule_conf:

--- a/tests/test_multi_value_mark.py
+++ b/tests/test_multi_value_mark.py
@@ -90,7 +90,12 @@ def test_happy_path():
     pass
     """)
     result = flake8dir.run_flake8(extra_args)
-    assert result.out_lines == [u"./example.py:1:1: M601 the mark values '['']' do not match the configuration specified by pytest_mark1, Validation supplied, but values absent.", u'./example.py:1:1: M701 mark values must be strings']
+    err1 = "./example.py:1:1: M601 the mark values '['']' do " + \
+           "not match the configuration specified by pytest_mark1, " + \
+           "Validation supplied, but values absent."
+    err2 = u'./example.py:1:1: M701 mark values must be strings'
+    expected_results = [err1, err2]
+    assert result.out_lines == expected_results
 
 
 def test_multiple_values_that_are_not_strings(flake8dir):
@@ -116,4 +121,7 @@ def test_happy_path():
     pass
     """)
     result = flake8dir.run_flake8(extra_args)
-    assert result.out_lines == [u"./example.py:1:1: M601 the mark values '['']' do not match the configuration specified by pytest_mark1, Validation supplied, but values absent."]
+    expected_result = "./example.py:1:1: M601 the mark values '['']' do " + \
+                      "not match the configuration specified by pytest_mark1, " + \
+                      "Validation supplied, but values absent."
+    assert result.out_lines == [expected_result]

--- a/tests/test_multi_value_mark.py
+++ b/tests/test_multi_value_mark.py
@@ -43,6 +43,40 @@ def test_happy_path():
     assert result.out_lines == ["./example.py:1:1: M601 the mark values '['bad', 'not_good', 'really bad']' do not match the configuration specified by pytest_mark1, Configured regex: '[a-zA-Z]*-\\d*'"]  # noqa
 
 
+def test_mark_with_ast_call(flake8dir):
+    config = r"""
+[flake8]
+pytest_mark1 = name=jira,value_regex=[a-zA-Z]*-\d*,allow_multiple_args=true
+pytest_mark3 = name=test_case_with_steps
+    """
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.jira()
+@pytest.mark.test_case_with_steps()
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_mark_with_ast_attr(flake8dir):
+    config = r"""
+[flake8]
+pytest_mark1 = name=jira,value_regex=[a-zA-Z]*-\d*,allow_multiple_args=true
+pytest_mark3 = name=test_case_with_steps
+    """
+    flake8dir.make_setup_cfg(config)
+    flake8dir.make_example_py("""
+@pytest.mark.jira()
+@pytest.mark.test_case_with_steps
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
 def test_values_that_are_not_strings(flake8dir):
     flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""


### PR DESCRIPTION
Prior to this change, marks without parens were being
ignored.

This Commit adds logic in rules.py to diferentiate
between ast.Call and ast.Attribute and adds a couple
tests around this issue.